### PR TITLE
type object updated from object to Object

### DIFF
--- a/src/particles.component.ts
+++ b/src/particles.component.ts
@@ -14,7 +14,7 @@ export class ParticlesComponent {
     @Input() width: number = 100;
     @Input() height: number = 100;
     @Input() params: IParams;
-    @Input() style: object = {};
+    @Input() style: Object = {};
 
     constructor() { }
 }


### PR DESCRIPTION
I was getting a error of -- 
ERROR in D:/NG-2/challanger2/node_modules/angular-particle/particles.component.d.ts (6,12): Cannot find name 'object'.
webpack: Failed to compile.

so i have updated type, after doing this change, it was working fine for me, please merge same so that it wont fail next time .
