### PR TITLE
Use parameter 'params' instead of attribute in loadImg function

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -202,7 +202,7 @@ export const getDefaultParams: () => IParams =
 
 
 export function loadImg(params: IParams, tmp: ITmpParams) {
-    let { particles } = this.params;
+    let { particles } = params;
 
     tmp.img_error = undefined;
 


### PR DESCRIPTION
Use parameter 'params' instead of attribute in loadImg function because function is not part of a class.